### PR TITLE
Clear Shopware's in-memory webhook cache when disabling webhooks via API *DRAFT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.18/1.7.18/1.6.18/1.5.18 03.2026
+- Webhook status: Clear Shopware's in-memory webhook cache when disabling webhooks via API
+
 ## 2.0.17/1.7.17/1.6.17/1.5.17 03.2026
 - Snippet list route: add optional `translationKeys` filter for efficient single-entry lookups
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "reqser/shopware-plugin",
     "description": "AI Reqser.com Extension Plugin",
-    "version": "2.0.17",
+    "version": "2.0.18",
     "type": "shopware-platform-plugin",
     "license": "proprietary",
     "authors": [

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -170,6 +170,7 @@
         <service id="Reqser\Plugin\Service\ReqserWebhookManagementService">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="webhook.repository"/>
+            <argument type="service" id="Shopware\Core\Framework\Webhook\WebhookCacheClearer"/>
         </service>
 
         <!-- API Controllers -->

--- a/src/Service/ReqserWebhookManagementService.php
+++ b/src/Service/ReqserWebhookManagementService.php
@@ -7,18 +7,22 @@ use Reqser\Plugin\ReqserPlugin;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Webhook\WebhookCacheClearer;
 
 class ReqserWebhookManagementService
 {
     private Connection $connection;
     private EntityRepository $webhookRepository;
+    private WebhookCacheClearer $webhookCacheClearer;
 
     public function __construct(
         Connection $connection,
-        EntityRepository $webhookRepository
+        EntityRepository $webhookRepository,
+        WebhookCacheClearer $webhookCacheClearer
     ) {
         $this->connection = $connection;
         $this->webhookRepository = $webhookRepository;
+        $this->webhookCacheClearer = $webhookCacheClearer;
     }
 
     /**
@@ -84,6 +88,10 @@ class ReqserWebhookManagementService
                 'active' => $active,
             ],
         ], Context::createDefaultContext());
+
+        // Shopware's WebhookManager caches the webhook list in memory. Without clearing the cache,
+        // disabled webhooks would still be dispatched until the PHP process restarts (e.g. cache:clear).
+        $this->webhookCacheClearer->clearWebhookCache();
 
         return [
             'webhookName' => $webhook['name'],


### PR DESCRIPTION
Made-with: Cursor