### PR TITLE
Update version to 2.0.33 and introduce a new `snippets/storefront` route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.33/1.7.33/1.6.33/1.5.33 06.2026
+- New `snippets/storefront` route: returns the storefront-effective snippet values, so file-only snippets resolved via a fallback locale are no longer reported as empty
+
 ## 2.0.32/1.7.32/1.6.32/1.5.32 06.2026
 - `cms/twig-files`: fall back to reading the physical source file when a Twig ref cannot be resolved, so structural core templates are still captured
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "reqser/shopware-plugin",
     "description": "AI Reqser.com Extension Plugin",
-    "version": "2.0.32",
+    "version": "2.0.33",
     "type": "shopware-platform-plugin",
     "license": "proprietary",
     "authors": [

--- a/src/Core/Api/Controller/ReqserSnippetListApiController.php
+++ b/src/Core/Api/Controller/ReqserSnippetListApiController.php
@@ -4,6 +4,7 @@ namespace Reqser\Plugin\Core\Api\Controller;
 
 use Reqser\Plugin\Core\Api\Attribute\ReqserApiAuth;
 use Reqser\Plugin\Service\ReqserSnippetListService;
+use Reqser\Plugin\Service\ReqserSnippetStorefrontService;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\System\Snippet\SnippetException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -17,9 +18,11 @@ class ReqserSnippetListApiController extends AbstractController
 {
     /**
      * @param ReqserSnippetListService $snippetListService
+     * @param ReqserSnippetStorefrontService $snippetStorefrontService
      */
     public function __construct(
-        private readonly ReqserSnippetListService $snippetListService
+        private readonly ReqserSnippetListService $snippetListService,
+        private readonly ReqserSnippetStorefrontService $snippetStorefrontService
     ) {
     }
 
@@ -96,5 +99,50 @@ class ReqserSnippetListApiController extends AbstractController
         );
 
         return new JsonResponse($result);
+    }
+
+    /**
+     * Return storefront-effective snippet values for the given snippet sets.
+     *
+     * Request body:
+     * - snippetSetIds (array|string, required)
+     * - translationKeys (array, optional)
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    #[Route(
+        path: '/api/_action/reqser/snippets/storefront',
+        name: 'api.action.reqser.snippets.storefront',
+        methods: ['POST']
+    )]
+    public function getStorefrontSnippets(Request $request): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true) ?? [];
+
+        $snippetSetIds = $payload['snippetSetIds'] ?? $payload['snippetSetId'] ?? null;
+        if (\is_string($snippetSetIds)) {
+            $snippetSetIds = [$snippetSetIds];
+        }
+
+        if (!\is_array($snippetSetIds) || $snippetSetIds === []) {
+            return new JsonResponse([
+                'success' => false,
+                'error' => 'Missing required parameter',
+                'message' => 'The parameter "snippetSetIds" is required'
+            ], 400);
+        }
+
+        $translationKeys = $payload['translationKeys'] ?? null;
+        if ($translationKeys !== null && !\is_array($translationKeys)) {
+            $translationKeys = null;
+        }
+
+        $data = $this->snippetStorefrontService->getStorefrontSnippetsForSets(
+            array_values($snippetSetIds),
+            $translationKeys
+        );
+
+        return new JsonResponse(['data' => $data]);
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -130,6 +130,11 @@
             <argument type="service" id="Shopware\Core\System\Snippet\SnippetService"/>
         </service>
 
+        <service id="Reqser\Plugin\Service\ReqserSnippetStorefrontService">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\System\Snippet\SnippetService"/>
+        </service>
+
         <service id="Reqser\Plugin\Service\ReqserJsonFieldDetectionService">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
@@ -182,6 +187,7 @@
         <!-- API Controllers -->
         <service id="Reqser\Plugin\Core\Api\Controller\ReqserSnippetListApiController" public="true">
             <argument type="service" id="Reqser\Plugin\Service\ReqserSnippetListService" />
+            <argument type="service" id="Reqser\Plugin\Service\ReqserSnippetStorefrontService" />
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>

--- a/src/Service/ReqserSnippetStorefrontService.php
+++ b/src/Service/ReqserSnippetStorefrontService.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types=1);
+
+namespace Reqser\Plugin\Service;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Snippet\SnippetService;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Resolves the storefront-effective snippet values (locale fallback, theme files and DB overrides applied) for snippet sets.
+ */
+class ReqserSnippetStorefrontService
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly SnippetService $snippetService
+    ) {
+    }
+
+    /**
+     * Return the storefront-effective snippet map per snippet set.
+     *
+     * Mirrors what Shopware's storefront serves: SnippetService::getStorefrontSnippets()
+     * applies the system-default locale as fallback, includes the sales channel's theme
+     * snippet files and overlays DB overrides. Unlike the admin getList route, file-only
+     * snippets that exist only in a fallback-locale file (e.g. a de-DE plugin file rendered
+     * under a de-CH snippet set) resolve to their fallback value instead of an empty blank.
+     *
+     * @param array<int, string> $snippetSetIds
+     * @param array<int, string>|null $translationKeys When provided, restrict the result to these keys.
+     * @return array<string, array<string, string>> snippetSetId => (translationKey => value)
+     */
+    public function getStorefrontSnippetsForSets(array $snippetSetIds, array|null $translationKeys = null): array
+    {
+        $fallback_locale = $this->getSystemDefaultLocale();
+        $key_filter = ($translationKeys !== null) ? array_flip($translationKeys) : null;
+
+        $result = [];
+        foreach ($snippetSetIds as $snippet_set_id) {
+            if (!\is_string($snippet_set_id) || $snippet_set_id === '' || !Uuid::isValid($snippet_set_id)) {
+                continue;
+            }
+
+            $locale = $this->getSnippetSetIso($snippet_set_id);
+            if ($locale === null) {
+                continue;
+            }
+
+            $sales_channel_id = $this->getSalesChannelIdForSnippetSet($snippet_set_id);
+
+            $snippets = $this->snippetService->getStorefrontSnippets(
+                new MessageCatalogue($locale),
+                $snippet_set_id,
+                $fallback_locale,
+                $sales_channel_id
+            );
+
+            if ($key_filter !== null) {
+                $snippets = array_intersect_key($snippets, $key_filter);
+            }
+
+            $result[$snippet_set_id] = $snippets;
+        }
+
+        return $result;
+    }
+
+    private function getSnippetSetIso(string $snippet_set_id): string|null
+    {
+        $iso = $this->connection->fetchOne(
+            'SELECT iso FROM snippet_set WHERE id = :id',
+            ['id' => Uuid::fromHexToBytes($snippet_set_id)]
+        );
+
+        return $iso === false ? null : (string) $iso;
+    }
+
+    private function getSalesChannelIdForSnippetSet(string $snippet_set_id): string|null
+    {
+        $sales_channel_id = $this->connection->fetchOne(
+            'SELECT LOWER(HEX(sales_channel_id)) FROM sales_channel_domain WHERE snippet_set_id = :id LIMIT 1',
+            ['id' => Uuid::fromHexToBytes($snippet_set_id)]
+        );
+
+        return $sales_channel_id === false ? null : (string) $sales_channel_id;
+    }
+
+    private function getSystemDefaultLocale(): string
+    {
+        $locale = $this->connection->fetchOne(
+            'SELECT locale.code
+             FROM language
+             INNER JOIN locale ON language.locale_id = locale.id
+             WHERE language.id = :languageId',
+            ['languageId' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM)]
+        );
+
+        return $locale === false ? 'en-GB' : (string) $locale;
+    }
+}


### PR DESCRIPTION
in `ReqserSnippetListApiController` to return storefront-effective snippet values, ensuring that file-only snippets resolved via a fallback locale are no longer reported as empty. Add `ReqserSnippetStorefrontService` to handle the logic for retrieving these snippets. Update changelog to reflect these changes.