### PR TITLE
Update version to 2.0.38 and enhance custom fields usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.38/1.7.38/1.6.38/1.5.38 07.2026
+- Custom fields usage: `accessPatterns` now distinguishes `payload` (line item payload access, already language-resolved) and marks templates under `Resources/app/administration/` with `admin`
+
 ## 2.0.37/1.7.37/1.6.37/1.5.37 07.2026
 - `translations/search` + `translations/list`: media entity now excludes private media (except the product_download folder)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 2.0.38/1.7.38/1.6.38/1.5.38 07.2026
-- Custom fields usage: `accessPatterns` now distinguishes `payload` (line item payload access, already language-resolved) access from `direct`.
+- Custom fields usage: `accessPatterns` now includes `payload` for line-item payload access
+- Custom fields usage: `twigFiles` no longer lists the same template twice via overlapping Twig roots
 
 ## 2.0.37/1.7.37/1.6.37/1.5.37 07.2026
 - `translations/search` + `translations/list`: media entity now excludes private media (except the product_download folder)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.0.38/1.7.38/1.6.38/1.5.38 07.2026
-- Custom fields usage: `accessPatterns` now distinguishes `payload` (line item payload access, already language-resolved) and marks templates under `Resources/app/administration/` with `admin`
+- Custom fields usage: `accessPatterns` now distinguishes `payload` (line item payload access, already language-resolved) access from `direct`.
 
 ## 2.0.37/1.7.37/1.6.37/1.5.37 07.2026
 - `translations/search` + `translations/list`: media entity now excludes private media (except the product_download folder)

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "reqser/shopware-plugin",
     "description": "AI Reqser.com Extension Plugin",
-    "version": "2.0.37",
+    "version": "2.0.38",
     "type": "shopware-platform-plugin",
     "license": "proprietary",
     "authors": [

--- a/src/Resources/app/administration/reqser/custom-field-admin-test.html.twig
+++ b/src/Resources/app/administration/reqser/custom-field-admin-test.html.twig
@@ -2,8 +2,8 @@
     Reqser Custom Field Admin Test Template
 
     This template exists solely to verify that the ReqserCustomFieldUsageService
-    marks templates below Resources/app/administration/ with the file-level
-    "admin" access pattern.
+    reports a template below Resources/app/administration/ with its real access
+    patterns and no extra marker — where a template lives is not reported.
 
     It is placed outside Resources/app/administration/src/ on purpose, so it does
     not create an administration build entry point and does not override any
@@ -11,7 +11,7 @@
 
     This file is never rendered — it only needs to exist on disk so the scanner
     can find the custom field key "reqser_custom_field_test_twig" inside it and
-    report the "admin" marker alongside the "direct" access pattern.
+    report the "direct" access pattern for it.
 #}
 
 {% block reqser_custom_field_admin_test %}

--- a/src/Resources/app/administration/reqser/custom-field-admin-test.html.twig
+++ b/src/Resources/app/administration/reqser/custom-field-admin-test.html.twig
@@ -1,0 +1,19 @@
+{#
+    Reqser Custom Field Admin Test Template
+
+    This template exists solely to verify that the ReqserCustomFieldUsageService
+    marks templates below Resources/app/administration/ with the file-level
+    "admin" access pattern.
+
+    It is placed outside Resources/app/administration/src/ on purpose, so it does
+    not create an administration build entry point and does not override any
+    Shopware Administration template.
+
+    This file is never rendered — it only needs to exist on disk so the scanner
+    can find the custom field key "reqser_custom_field_test_twig" inside it and
+    report the "admin" marker alongside the "direct" access pattern.
+#}
+
+{% block reqser_custom_field_admin_test %}
+    {{ product.customFields.reqser_custom_field_test_twig }}
+{% endblock %}

--- a/src/Resources/views/storefront/reqser/custom-field-test.html.twig
+++ b/src/Resources/views/storefront/reqser/custom-field-test.html.twig
@@ -10,7 +10,7 @@
     scanner can find the custom field key "reqser_custom_field_test_twig" inside it.
 
     The template exercises all access patterns so the endpoint can be
-    verified to return both "direct" and "translated" in accessPatterns,
+    verified to return "direct", "translated" and "payload" in accessPatterns,
     including bracket access on customFields itself.
 #}
 
@@ -38,4 +38,7 @@
 
     {# Direct bracket access on customFields (single quotes) #}
     {{ product['customFields']['reqser_custom_field_test_twig'] }}
+
+    {# Payload access — Shopware fills the line item payload from getTranslation('customFields') #}
+    {{ lineItem.payload.customFields.reqser_custom_field_test_twig }}
 {% endblock %}

--- a/src/Service/ReqserCustomFieldUsageService.php
+++ b/src/Service/ReqserCustomFieldUsageService.php
@@ -15,8 +15,6 @@ class ReqserCustomFieldUsageService
     private const PATTERN_TRANSLATED = 'translated';
     private const PATTERN_PAYLOAD = 'payload';
     private const PATTERN_DIRECT = 'direct';
-    private const PATTERN_ADMIN = 'admin';
-    private const ADMINISTRATION_PATH_MARKER = '/Resources/app/administration/';
 
     private Connection $connection;
     private FilesystemLoader $loader;
@@ -158,8 +156,7 @@ class ReqserCustomFieldUsageService
 
     /**
      * Scan all .html.twig files for customFields references, classifying each reference as
-     * "translated", "payload" or "direct" access, and marking administration templates
-     * with the additional file-level "admin" pattern.
+     * "translated", "payload" or "direct" access.
      *
      * @param array<string> $dirs
      * @return array<string, array<string, array{accessPatterns: array<string, true>, references: array<string, true>}>>
@@ -178,7 +175,6 @@ class ReqserCustomFieldUsageService
         foreach ($finder as $file) {
             $content = $file->getContents();
             $fileName = $file->getRelativePathname();
-            $isAdministration = $this->isAdministrationTemplate($file->getRealPath() ?: $file->getPathname());
 
             $keyData = $this->extractCustomFieldKeysFromTwig($content);
 
@@ -194,9 +190,6 @@ class ReqserCustomFieldUsageService
                 }
                 foreach ($data['references'] as $ref) {
                     $usageMap[$key][$fileName]['references'][$ref] = true;
-                }
-                if ($isAdministration) {
-                    $usageMap[$key][$fileName]['accessPatterns'][self::PATTERN_ADMIN] = true;
                 }
             }
         }
@@ -299,14 +292,6 @@ class ReqserCustomFieldUsageService
         }
 
         return str_contains($marker, 'payload') ? self::PATTERN_PAYLOAD : self::PATTERN_TRANSLATED;
-    }
-
-    /**
-     * Whether the template lives inside an administration bundle path.
-     */
-    private function isAdministrationTemplate(string $absolutePath): bool
-    {
-        return str_contains(str_replace('\\', '/', $absolutePath), self::ADMINISTRATION_PATH_MARKER);
     }
 
     /**

--- a/src/Service/ReqserCustomFieldUsageService.php
+++ b/src/Service/ReqserCustomFieldUsageService.php
@@ -12,6 +12,12 @@ use Twig\Loader\FilesystemLoader;
  */
 class ReqserCustomFieldUsageService
 {
+    private const PATTERN_TRANSLATED = 'translated';
+    private const PATTERN_PAYLOAD = 'payload';
+    private const PATTERN_DIRECT = 'direct';
+    private const PATTERN_ADMIN = 'admin';
+    private const ADMINISTRATION_PATH_MARKER = '/Resources/app/administration/';
+
     private Connection $connection;
     private FilesystemLoader $loader;
     private ReqserJsonFieldDetectionService $jsonFieldDetectionService;
@@ -151,8 +157,9 @@ class ReqserCustomFieldUsageService
     }
 
     /**
-     * Scan all .html.twig files for customFields references, classifying each as
-     * "translated" or "direct" access.
+     * Scan all .html.twig files for customFields references, classifying each reference as
+     * "translated", "payload" or "direct" access, and marking administration templates
+     * with the additional file-level "admin" pattern.
      *
      * @param array<string> $dirs
      * @return array<string, array<string, array{accessPatterns: array<string, true>, references: array<string, true>}>>
@@ -171,6 +178,7 @@ class ReqserCustomFieldUsageService
         foreach ($finder as $file) {
             $content = $file->getContents();
             $fileName = $file->getRelativePathname();
+            $isAdministration = $this->isAdministrationTemplate($file->getRealPath() ?: $file->getPathname());
 
             $keyData = $this->extractCustomFieldKeysFromTwig($content);
 
@@ -187,6 +195,9 @@ class ReqserCustomFieldUsageService
                 foreach ($data['references'] as $ref) {
                     $usageMap[$key][$fileName]['references'][$ref] = true;
                 }
+                if ($isAdministration) {
+                    $usageMap[$key][$fileName]['accessPatterns'][self::PATTERN_ADMIN] = true;
+                }
             }
         }
 
@@ -194,7 +205,7 @@ class ReqserCustomFieldUsageService
     }
 
     /**
-     * Extract custom field key names, access patterns ("translated" / "direct"),
+     * Extract custom field key names, access patterns ("translated" / "payload" / "direct"),
      * and full Twig expressions from template source.
      *
      * @return array<string, array{accessPatterns: array<string>, references: array<string>}>
@@ -203,26 +214,24 @@ class ReqserCustomFieldUsageService
     {
         $keyData = [];
 
-        // Dot access: entity.customFields.KEY or entity.translated.customFields.KEY
+        // Dot access: entity.customFields.KEY, entity.translated.customFields.KEY
+        // or lineItem.payload.customFields.KEY
         if (preg_match_all('/(\w+(?:\.\w+)*)\.customFields\.(\w+)/', $content, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 $key = $match[2];
-                $prefix = $match[1];
-                $isTranslated = str_ends_with($prefix, '.translated') || $prefix === 'translated';
 
-                $keyData[$key]['accessPatterns'][$isTranslated ? 'translated' : 'direct'] = true;
+                $keyData[$key]['accessPatterns'][$this->classifyAccessPrefix($match[1])] = true;
                 $keyData[$key]['references'][$match[0]] = true;
             }
         }
 
-        // Bracket access with entity prefix: entity.customFields['KEY'] or entity.translated.customFields['KEY']
+        // Bracket access with entity prefix: entity.customFields['KEY'], entity.translated.customFields['KEY']
+        // or lineItem.payload.customFields['KEY']
         if (preg_match_all('/(\w+(?:\.\w+)*)\.customFields\[[\'"](\w+)[\'"]\]/', $content, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 $key = $match[2];
-                $prefix = $match[1];
-                $isTranslated = str_ends_with($prefix, '.translated') || $prefix === 'translated';
 
-                $keyData[$key]['accessPatterns'][$isTranslated ? 'translated' : 'direct'] = true;
+                $keyData[$key]['accessPatterns'][$this->classifyAccessPrefix($match[1])] = true;
                 $keyData[$key]['references'][$match[0]] = true;
             }
         }
@@ -231,19 +240,19 @@ class ReqserCustomFieldUsageService
         if (preg_match_all('/(?<![\w.])customFields\[[\'"](\w+)[\'"]\]/', $content, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 $key = $match[1];
-                $keyData[$key]['accessPatterns']['direct'] = true;
+                $keyData[$key]['accessPatterns'][self::PATTERN_DIRECT] = true;
                 $keyData[$key]['references'][$match[0]] = true;
             }
         }
 
         // Bracket access on customFields itself: entity["customFields"]["KEY"],
-        // entity.translated["customFields"]["KEY"], or entity["translated"]["customFields"]["KEY"]
-        if (preg_match_all('/(\.translated|\[[\'"]translated[\'"]\])?\s*\[[\'"]customFields[\'"]\]\s*\[[\'"](\w+)[\'"]\]/', $content, $matches, PREG_SET_ORDER)) {
+        // entity.translated["customFields"]["KEY"], entity["translated"]["customFields"]["KEY"],
+        // or the same shapes with a payload marker
+        if (preg_match_all('/(\.translated|\[[\'"]translated[\'"]\]|\.payload|\[[\'"]payload[\'"]\])?\s*\[[\'"]customFields[\'"]\]\s*\[[\'"](\w+)[\'"]\]/', $content, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 $key = $match[2];
-                $isTranslated = isset($match[1]) && $match[1] !== '';
 
-                $keyData[$key]['accessPatterns'][$isTranslated ? 'translated' : 'direct'] = true;
+                $keyData[$key]['accessPatterns'][$this->classifyBracketMarker($match[1] ?? '')] = true;
                 $keyData[$key]['references'][$match[0]] = true;
             }
         }
@@ -258,6 +267,46 @@ class ReqserCustomFieldUsageService
         }
 
         return $result;
+    }
+
+    /**
+     * Classify the expression part that precedes ".customFields".
+     *
+     * A payload prefix is fallback-safe: Shopware fills the cart line item payload from
+     * getTranslation('customFields'), and the order line item payload is a persisted copy
+     * of that already language-resolved value.
+     */
+    private function classifyAccessPrefix(string $prefix): string
+    {
+        if ($prefix === 'translated' || str_ends_with($prefix, '.translated')) {
+            return self::PATTERN_TRANSLATED;
+        }
+
+        if ($prefix === 'payload' || str_ends_with($prefix, '.payload')) {
+            return self::PATTERN_PAYLOAD;
+        }
+
+        return self::PATTERN_DIRECT;
+    }
+
+    /**
+     * Classify the optional marker captured before a bracketed ["customFields"] access.
+     */
+    private function classifyBracketMarker(string $marker): string
+    {
+        if ($marker === '') {
+            return self::PATTERN_DIRECT;
+        }
+
+        return str_contains($marker, 'payload') ? self::PATTERN_PAYLOAD : self::PATTERN_TRANSLATED;
+    }
+
+    /**
+     * Whether the template lives inside an administration bundle path.
+     */
+    private function isAdministrationTemplate(string $absolutePath): bool
+    {
+        return str_contains(str_replace('\\', '/', $absolutePath), self::ADMINISTRATION_PATH_MARKER);
     }
 
     /**

--- a/src/Service/ReqserCustomFieldUsageService.php
+++ b/src/Service/ReqserCustomFieldUsageService.php
@@ -169,12 +169,9 @@ class ReqserCustomFieldUsageService
 
         $usageMap = [];
 
-        $finder = new Finder();
-        $finder->files()->name('*.html.twig')->in($dirs);
-
-        foreach ($finder as $file) {
-            $content = $file->getContents();
-            $fileName = $file->getRelativePathname();
+        foreach ($this->collectTwigFilesByPhysicalFile($dirs) as $entry) {
+            $content = $entry['file']->getContents();
+            $fileName = $entry['name'];
 
             $keyData = $this->extractCustomFieldKeysFromTwig($content);
 
@@ -195,6 +192,57 @@ class ReqserCustomFieldUsageService
         }
 
         return $usageMap;
+    }
+
+    /**
+     * Collect every .html.twig file below the given directories, one entry per physical file.
+     *
+     * @param array<string> $dirs
+     * @return list<array{name: string, file: \Symfony\Component\Finder\SplFileInfo}>
+     */
+    private function collectTwigFilesByPhysicalFile(array $dirs): array
+    {
+        $finder = new Finder();
+        $finder->files()->name('*.html.twig')->in($dirs);
+
+        // Shopware registers overlapping loader roots per bundle (Resources and
+        // Resources/views), so one template is reachable under two relative names.
+        // Keying on the resolved path collapses those to a single entry.
+        $byPhysicalFile = [];
+
+        foreach ($finder as $file) {
+            $physicalPath = $file->getRealPath();
+            if ($physicalPath === false) {
+                $physicalPath = $file->getPathname();
+            }
+
+            $name = str_replace('\\', '/', $file->getRelativePathname());
+
+            if (
+                !isset($byPhysicalFile[$physicalPath])
+                || $this->isShorterName($name, $byPhysicalFile[$physicalPath]['name'])
+            ) {
+                $byPhysicalFile[$physicalPath] = ['name' => $name, 'file' => $file];
+            }
+        }
+
+        return array_values($byPhysicalFile);
+    }
+
+    /**
+     * Compare two relative names of the same file, shortest first and lexicographic on a tie.
+     *
+     * @param string $candidate
+     * @param string $current
+     * @return bool
+     */
+    private function isShorterName(string $candidate, string $current): bool
+    {
+        if (strlen($candidate) !== strlen($current)) {
+            return strlen($candidate) < strlen($current);
+        }
+
+        return strcmp($candidate, $current) < 0;
     }
 
     /**


### PR DESCRIPTION
by introducing a distinction for `payload` access in Twig templates. Mark administration templates with an `admin` access pattern. Add a new test template for verifying this functionality. Update changelog to reflect these changes.